### PR TITLE
Fix duplicate exception handling in update_prompt_schema

### DIFF
--- a/gemini_structured_response_prompts_database/schema_manager.py
+++ b/gemini_structured_response_prompts_database/schema_manager.py
@@ -45,11 +45,12 @@ class SchemaManager:
         self.table = table
         self.default_prompt_type = default_prompt_type or self.DEFAULT_PROMPT_TYPE
         self.default_prompt_text = default_prompt_text or self.DEFAULT_PROMPT_TEXT
-        self.default_response_schema = default_response_schema or self.DEFAULT_RESPONSE_SCHEMA
         self.default_response_schema = (
             default_response_schema or self.DEFAULT_RESPONSE_SCHEMA
         )
-
+        self.default_response_schema = (
+            default_response_schema or self.DEFAULT_RESPONSE_SCHEMA
+        )
 
     def _db_to_pydantic(
         self, db_model: Union[PromptSchemaDB, PromptResponseDB]
@@ -77,7 +78,9 @@ class SchemaManager:
         try:
             result = await self.database.get_schema(prompt_id)
             if not result:
-                raise HTTPException(status_code=404, detail=f"Schema not found for id: {prompt_id}")
+                raise HTTPException(
+                    status_code=404, detail=f"Schema not found for id: {prompt_id}"
+                )
                 raise HTTPException(
                     status_code=404, detail=f"Schema not found for type: {prompt_type}"
                 )
@@ -129,16 +132,14 @@ class SchemaManager:
         response_schema: Optional[Dict] = None,
         model_instruction: Optional[str] = None,
         additional_messages: Optional[List[Dict[str, str]]] = None,
-
         **kwargs,
     ) -> PromptSchema:
         """Update an existing prompt schema"""
         try:
             existing = await self.database.get_schema(prompt_id)
             if not existing:
-                raise HTTPException(status_code=404, detail=f"Schema not found for id: {prompt_id}")
                 raise HTTPException(
-                    status_code=404, detail=f"Schema not found for type: {prompt_type}"
+                    status_code=404, detail=f"Schema not found for id: {prompt_id}"
                 )
 
             update_data = {


### PR DESCRIPTION
## Summary
- remove repeated HTTPException branch when updating prompt schema
- keep the file formatted with `black`

## Testing
- `python -m py_compile gemini_structured_response_prompts_database/schema_manager.py`
- `flake8 gemini_structured_response_prompts_database/schema_manager.py` *(fails: command not found)*
- `black --check gemini_structured_response_prompts_database/schema_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6850c11104b4832f8685f379ab790dc4